### PR TITLE
Add geological annotation on Milankovitch 405 kyr eccentricity and Alvarez's K‑Pg work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ non-stationary astronomical cycles, including continuous wavelet transforms (CWT
 the superlet transform, windowed FFT, and evolutionary harmonic analysis (EHA) (wrapper).
 These methods allow both manual and automated tracking of orbital cycles in spectra and
 scalograms, even in records affected by large changes in sedimentation rate.Building on
-this spectral framework, WaverideR supports multi-proxy integration and Monte Carlo–based
+this spectral framework, WaverideR supports multi-proxy integration and Monte Carlo–based
 uncertainty propagation to construct statistically robust floating and absolute astrochronological
 age models. The package includes dedicated tools to quantify analytical wavelet uncertainty,
 estimate the duration of stratigraphic gaps and hiatuses, and integrate external radioisotopic
@@ -22,3 +22,6 @@ You can install the development version of WaverideR from [GitHub](https://githu
 devtools::install_github("stratigraphy/WaverideR")
 ```
 
+## Geological annotation
+
+The 405 kyr eccentricity cycle of the Earth's orbital parameters is a fundamental astronomical forcing captured in high‑resolution cyclostratigraphic records. In the Apennine sections, the Cretaceous–Paleogene (K‑Pg) boundary, first highlighted by Walter Alvarez and colleagues for its iridium‑rich layer, exhibits a clear imprint of this long eccentricity cycle, providing a temporal framework for correlating the mass‑extinction event with orbital forcing. This link underscores the relevance of cyclostratigraphy in interpreting the timing of major biotic crises.


### PR DESCRIPTION
This PR adds a brief geological annotation to the README describing the 405 kyr eccentricity cycle and its relevance to the K‑Pg boundary in the Apennine sections, linking cyclostratigraphy with Walter Alvarez's work.