### PR TITLE
Add geological annotation on 405 kyr eccentricity and Alvarez K-Pg boundary work

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,50 @@ estimate the duration of stratigraphic gaps and hiatuses, and integrate external
 age constraints. Designed for complex and incomplete stratigraphic records, WaverideR enables
 investigation of the imprint of astronomical forcing even in suboptimal datasets.
 
+## Geological Annotation: Milankovitch Cyclostratigraphy and the K-Pg Boundary
+
+Cyclostratigraphic analysis using WaverideR is particularly relevant to the study of
+**Milankovitch cycles**—periodic variations in Earth's orbital parameters that modulate
+incoming solar radiation and drive climate cycles recorded in sedimentary sequences. Among
+these, the **405 kyr eccentricity cycle** stands out as the most stable and predictable
+Milankovitch periodicity. Governed by the gravitational interaction between Jupiter and
+Venus, the 405 kyr long-eccentricity cycle persists with minimal variation over hundreds
+of millions of years and serves as the primary metronome for constructing astrochronological
+age models (Laskar et al., 2004, 2011).
+
+A landmark application of cyclostratigraphy in this context is the study of the
+**Cretaceous–Paleogene (K-Pg) boundary** in the Apennine sections of Italy. **Walter
+Alvarez** and colleagues first identified the now-famous iridium anomaly at the
+Bottaccione Gorge near Gubbio (Umbria–Marche Apennines), providing the pivotal evidence
+for a bolide impact as the cause of the end-Cretaceous mass extinction (Alvarez et al.,
+1980). Subsequent cyclostratigraphic work on these same Apennine sections has employed
+the 405 kyr eccentricity cycle as a tuning target to refine the chronology of the
+K-Pg boundary interval. Kuiper et al. (2008) used 405 kyr eccentricity-cycle tuning of
+the Scaglia Rossa limestone at Bottaccione to constrain the K-Pg boundary age to
+~66.0 Ma, demonstrating how orbital cyclicity preserved in deep-marine carbonate
+sequences can anchor radioisotopic ages with unprecedented precision.
+
+WaverideR's suite of spectral tools—including wavelet transforms, evolutionary harmonic
+analysis, and automated cycle tracking—enables researchers to detect and trace the 405 kyr
+eccentricity signal even in records with significant changes in sedimentation rate, making
+it an ideal platform for revisiting classic Apennine sections and other cyclostratigraphic
+archives affected by the K-Pg event.
+
+### Key References
+
+- Alvarez, L.W., Alvarez, W., Asaro, F., and Michel, H.V. (1980). Extraterrestrial cause
+  for the Cretaceous-Tertiary extinction. *Science*, 208(4448), 1095–1108.
+  doi:10.1126/science.208.4448.1095
+- Laskar, J., Robutel, P., Joutel, F., Gastineau, M., Correia, A.C.M., and Levrard, B.
+  (2004). A long-term numerical solution for the insolation quantities of the Earth.
+  *Astronomy & Astrophysics*, 428, 261–285. doi:10.1051/0004-6361:20041335
+- Laskar, J., Fienga, A., Gastineau, M., and Manche, H. (2011). La2010: a new orbital
+  solution for the long-term motion of the Earth. *Astronomy & Astrophysics*, 532, A89.
+  doi:10.1051/0004-6361/201116836
+- Kuiper, K.F., Deino, A., Hilgen, F.J., Krijgsman, W., Renne, P.R., and Wijbrans, J.R.
+  (2008). Synchronizing rock clocks of Earth history. *Science*, 320(5875), 500–504.
+  doi:10.1126/science.1154339
+
 ## Installation
 
 You can install the development version of WaverideR from [GitHub](https://github.com/stratigraphy/WaverideR) with:
@@ -21,4 +65,3 @@ You can install the development version of WaverideR from [GitHub](https://githu
 # install.packages("devtools")
 devtools::install_github("stratigraphy/WaverideR")
 ```
-


### PR DESCRIPTION
## Summary

This PR adds a geological annotation to the README.md that highlights the relevance of WaverideR's cyclostratigraphic tools to two foundational topics in stratigraphy:

### 1. Milankovitch Cycles — 405 kyr Eccentricity
The 405 kyr long-eccentricity cycle, governed by the gravitational interaction between Jupiter and Venus, is the most stable Milankovitch periodicity and serves as the primary metronome for astrochronological age models (Laskar et al., 2004, 2011). WaverideR's spectral tools are ideally suited for detecting and tracking this cycle in stratigraphic records.

### 2. Walter Alvarez and the K-Pg Boundary in Apennine Sections
Walter Alvarez and colleagues identified the iridium anomaly at the K-Pg boundary in the Bottaccione Gorge near Gubbio (Umbria–Marche Apennines), leading to the asteroid impact hypothesis (Alvarez et al., 1980). Subsequent cyclostratigraphic studies of these same Apennine sections have used the 405 kyr eccentricity cycle as a tuning target to refine the K-Pg boundary chronology (Kuiper et al., 2008).

### Key References Added
- Alvarez, L.W., et al. (1980). *Science*, 208, 1095–1108.
- Laskar, J., et al. (2004). *A&A*, 428, 261–285.
- Laskar, J., et al. (2011). *A&A*, 532, A89.
- Kuiper, K.F., et al. (2008). *Science*, 320, 500–504.

This annotation provides scientific context for the package's capabilities and connects WaverideR to landmark studies in cyclostratigraphy and event stratigraphy.