### PR TITLE
Add cyclostratigraphic annotation: Milankovitch 405 kyr eccentricity and Alvarez K-Pg boundary work

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,28 @@ estimate the duration of stratigraphic gaps and hiatuses, and integrate external
 age constraints. Designed for complex and incomplete stratigraphic records, WaverideR enables
 investigation of the imprint of astronomical forcing even in suboptimal datasets.
 
+## Cyclostratigraphic Context
+
+WaverideR is particularly relevant for identifying Milankovitch cycles in stratigraphic records.
+The **405 kyr eccentricity cycle**, driven by the gravitational interaction of Jupiter and Venus
+(Laskar et al., 2004, 2011), serves as the fundamental metronome for astrochronological
+calibration due to its remarkable stability over hundreds of millions of years. This long-
+eccentricity period is widely used as a tuning target in cyclostratigraphic studies because it
+remains nearly constant even as other orbital parameters undergo secular variation.
+
+Walter Alvarez and colleagues demonstrated the application of cyclostratigraphy to the
+Cretaceous–Paleogene (K–Pg) boundary in the pelagic limestone sections of the Italian Apennines
+(e.g., Bottaccione Gorge, Contessa Highway). Their work showed that orbitally tuned cyclostratigraphy
+could precisely constrain the timing and duration of events surrounding the K–Pg mass extinction
+(Alvarez et al., 1977; Alvarez & Lowrie, 1978; Lowrie & Alvarez, 1981). These Apennine sections
+preserve rhythmic bedding that records Milankovitch-scale orbital forcing, enabling the detection
+of precession, obliquity, and eccentricity cycles—including the 405 kyr long eccentricity—which
+provides a robust chronostratigraphic framework across the K–Pg boundary interval.
+
+By enabling the detection and tracking of such orbital cycles, WaverideR facilitates the
+construction of high-resolution astrochronologies that directly build upon the foundational
+cyclostratigraphic work of Alvarez and others in the Apennine carbonate sequences.
+
 ## Installation
 
 You can install the development version of WaverideR from [GitHub](https://github.com/stratigraphy/WaverideR) with:
@@ -21,4 +43,3 @@ You can install the development version of WaverideR from [GitHub](https://githu
 # install.packages("devtools")
 devtools::install_github("stratigraphy/WaverideR")
 ```
-


### PR DESCRIPTION
## Summary

This PR adds a **Cyclostratigraphic Context** section to the README.md, providing a geological annotation that references:

1. **Milankovitch 405 kyr eccentricity cycle** — the long-eccentricity period driven by Jupiter–Venus gravitational interaction (Laskar et al., 2004, 2011), which serves as the fundamental metronome for astrochronological calibration due to its stability over geological timescales.

2. **Walter Alvarez's work on the K–Pg boundary** in the Apennine sections (Bottaccione Gorge, Contessa Highway) — pioneering cyclostratigraphic studies that used orbitally tuned rhythmic bedding in pelagic limestones to constrain the timing and duration of events around the Cretaceous–Paleogene mass extinction (Alvarez et al., 1977; Alvarez & Lowrie, 1978; Lowrie & Alvarez, 1981).

These annotations are directly relevant to the WaverideR package's core purpose of detecting and tracking astronomical cycles in stratigraphic data, and they connect the package's functionality to foundational cyclostratigraphic research.

## Changes
- Added a new `## Cyclostratigraphic Context` section to README.md
- Included discussion of the 405 kyr eccentricity cycle and its astrochronological significance
- Referenced Walter Alvarez's K–Pg boundary work in the Italian Apennines
- Connected these concepts to WaverideR's capabilities