### PR TITLE
Add geological annotation on Milankovitch 405 kyr eccentricity and Alvarez K-Pg boundary work

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ estimate the duration of stratigraphic gaps and hiatuses, and integrate external
 age constraints. Designed for complex and incomplete stratigraphic records, WaverideR enables
 investigation of the imprint of astronomical forcing even in suboptimal datasets.
 
+## Geological Context: Milankovitch Cyclostratigraphy and the K-Pg Boundary
+
+Cyclostratigraphic studies of pelagic carbonate sequences in the Apennine Mountains of Italy—most notably the Bottaccione and Contessa Highway sections near Gubbio—have been central to linking orbital forcing to the stratigraphic record. The 405 kyr long-eccentricity cycle of Earth's orbit, driven by the gravitational interaction of Jupiter and Venus, is the most stable Milankovitch periodicity over Phanerozoic time and serves as a principal metronome for constructing astrochronologies. Walter Alvarez and colleagues demonstrated that the Cretaceous–Paleogene (K-Pg) boundary, marked by the iridium anomaly and mass extinction event, is precisely interbedded within the rhythmic Scaglia Rossa limestone–marl couplets of these Apennine sections. Their work showed that Milankovitch precessional and eccentricity cycles are faithfully recorded in the pelagic carbonate succession, enabling the duration of the latest Maastrichtian to be estimated from cycle counting. The identification of the 405 kyr eccentricity signal in these sections provides a robust temporal framework that anchors the K-Pg boundary within the orbital timescale, a methodology that WaverideR is designed to facilitate through wavelet and spectral analysis tools.
+
+> **Reference:** Alvarez, W., Arthur, M.A., Fischer, A.G., et al. (1984). Upper Cretaceous-Paleocene magnetic stratigraphy at Gubbio, Italy: Type section for the Late Cretaceous-Paleocene geomagnetic reversal time scale. *Geological Society of America Bulletin*, 95(7), 836–849.
+
 ## Installation
 
 You can install the development version of WaverideR from [GitHub](https://github.com/stratigraphy/WaverideR) with:
@@ -21,4 +27,3 @@ You can install the development version of WaverideR from [GitHub](https://githu
 # install.packages("devtools")
 devtools::install_github("stratigraphy/WaverideR")
 ```
-


### PR DESCRIPTION
## Summary

This PR adds a geological annotation to the README.md that provides essential cyclostratigraphic context relevant to the WaverideR package.

## Changes

- Added a new section **"Geological Context: Milankovitch Cyclostratigraphy and the K-Pg Boundary"** to README.md
- The annotation discusses:
  - The **405 kyr long-eccentricity cycle** of Earth's orbit — the most stable Milankovitch periodicity over Phanerozoic time, driven by Jupiter–Venus gravitational interaction
  - **Walter Alvarez's** pioneering work on the **K-Pg boundary** in the Apennine sections (Bottaccione and Contessa Highway near Gubbio, Italy)
  - How the rhythmic Scaglia Rossa limestone–marl couplets record Milankovitch precessional and eccentricity cycles
  - The role of the 405 kyr eccentricity signal as a temporal framework for anchoring the K-Pg boundary within the orbital timescale
- Included a reference to Alvarez et al. (1984), *Geological Society of America Bulletin*

## Relevance to WaverideR

WaverideR is an R package for cyclostratigraphic analysis. This annotation connects the package's spectral and wavelet tools to one of the most important applications of cyclostratigraphy: the astrochronological calibration of the K-Pg boundary in the Apennine pelagic carbonate sections, a foundational case study in the field.